### PR TITLE
Adding support for variable annual rates schedules

### DIFF
--- a/Hledger/Interest/Rate.hs
+++ b/Hledger/Interest/Rate.hs
@@ -1,8 +1,9 @@
-module Hledger.Interest.Rate ( Rate, perAnno, constant, bgb288, ingDiba, db24 ) where
+module Hledger.Interest.Rate ( Rate, perAnno, perAnnoSchedule, constant, bgb288, ingDiba, db24 ) where
 
 import Data.Time.Calendar
 import Data.Time.Calendar.OrdinalDate
 import Data.Decimal
+import Data.List (sortOn)
 
 type Rate = Day -> (Day,Decimal)
 
@@ -10,10 +11,19 @@ constant :: Decimal -> Rate
 constant rate _ = (day 999999 12 31, rate)
 
 perAnno :: Decimal -> Rate
-perAnno rate date = (day (fst (toOrdinalDate date)) 12 31, rate)
+perAnno rate date = (yearEnd date, rate)
 
+perAnnoSchedule :: [(Day,Decimal)] -> Rate
+perAnnoSchedule schedule date = (yearEnd date, effectiveRate)
+  where
+    (_, effectiveRate) = last $ takeWhile (\(fromDate, _) -> fromDate<date) sortedSchedule
+    sortedSchedule = sortOn fst schedule
+        
 day :: Integer -> Int -> Int -> Day
 day = fromGregorian
+
+yearEnd :: Day -> Day
+yearEnd date = day (fst (toOrdinalDate date)) 12 31
 
 bgb288 :: Rate
 bgb288 = basiszins (5/100)

--- a/Main.hs
+++ b/Main.hs
@@ -62,6 +62,7 @@ options =
  , Option []    ["30E-360isda"]       (NoArg (\o -> o { optDCC = Just diff30E_360isda }))                  "use '30E/360isda' day counting convention"
  , Option []    ["constant"]          (ReqArg (\r o -> o { optRate = Just (constant (read r)) }) "RATE")   "constant interest rate"
  , Option []    ["annual"]            (ReqArg (\r o -> o { optRate = Just (perAnno (read r)) }) "RATE")    "annual interest rate"
+ , Option []    ["annual-schedule"]   (ReqArg (\r o -> o { optRate = Just (perAnnoSchedule (read r)) })    "SCHEDULE")    "schedule of annual interest rates.\nsyntax: '[(Date1,Rate1),(Date2,Rate2),...]'"
  , Option []    ["bgb288"]            (NoArg (\o -> o { optRate = Just bgb288, optDCC = Just diffAct }))   "compute interest according to German BGB288"
  , Option []    ["db24"]              (NoArg (\o -> o { optRate = Just db24, optDCC = Just diff30E_360 })) "HACK: Deutsche Bank 24"
  , Option []    ["ing-diba"]          (NoArg (\o -> o { optRate = Just ingDiba, optDCC = Just diffAct }))  "HACK: compute interest according for Ing-Diba Tagesgeld account"

--- a/README.md
+++ b/README.md
@@ -17,19 +17,21 @@ An overview over the available run-time options can be displayed by
 running "`hleder-interest --help`":
 
     Usage: hledger-interest [OPTION...] ACCOUNT
-      -v          --verbose         echo input ledger to stdout (default)
-      -q          --quiet           don't echo input ledger to stdout
-                  --today           compute interest up until today
-      -f FILE     --file=FILE       input ledger file (pass '-' for stdin)
-      -s ACCOUNT  --source=ACCOUNT  interest source account
-      -t ACCOUNT  --target=ACCOUNT  interest target account
-                  --act             use 'act' day counting convention
-                  --30-360          use '30/360' day counting convention
-                  --30E-360         use '30E/360' day counting convention
-                  --30E-360isda     use '30E/360isda' day counting convention
-                  --constant=RATE   constant interest rate
-                  --annual=RATE     annual interest rate
-                  --bgb288          compute interest according to German BGB288
+      -v          --verbose                   echo input ledger to stdout (default)
+      -q          --quiet                     don't echo input ledger to stdout
+                  --today                     compute interest up until today
+      -f FILE     --file=FILE                 input ledger file (pass '-' for stdin)
+      -s ACCOUNT  --source=ACCOUNT            interest source account
+      -t ACCOUNT  --target=ACCOUNT            interest target account
+                  --act                       use 'act' day counting convention
+                  --30-360                    use '30/360' day counting convention
+                  --30E-360                   use '30E/360' day counting convention
+                  --30E-360isda               use '30E/360isda' day counting convention
+                  --constant=RATE             constant interest rate
+                  --annual=RATE               annual interest rate
+                  --annual-schedule=SCHEDULE  schedule of annual interest rates.
+                                              syntax: '[(Date1,Rate1),(Date2,Rate2),...]'
+                  --bgb288                    compute interest according to German BGB288
 
 When run, hledger-interest reads the [ledger
 file](http://hledger.org/MANUAL.html#file-format) designated by the

--- a/hledger-interest.cabal
+++ b/hledger-interest.cabal
@@ -1,5 +1,5 @@
 Name:                   hledger-interest
-Version:                1.5.3
+Version:                1.5.4
 Synopsis:               computes interest for a given account
 License:                BSD3
 License-file:           LICENSE
@@ -92,22 +92,24 @@ Description:
  available options:
  .
  > Usage: hledger-interest [OPTION...] ACCOUNT
- >   -h          --help               print this message and exit
- >   -V          --version            show version number and exit
- >   -v          --verbose            echo input ledger to stdout (default)
- >   -q          --quiet              don't echo input ledger to stdout
- >               --today              compute interest up until today
- >   -f FILE     --file=FILE          input ledger file (pass '-' for stdin)
- >   -s ACCOUNT  --source=ACCOUNT     interest source account
- >   -t ACCOUNT  --target=ACCOUNT     interest target account
- >   -I          --ignore-assertions  ignore any failing balance assertions
- >               --act                use 'act' day counting convention
- >               --30-360             use '30/360' day counting convention
- >               --30E-360            use '30E/360' day counting convention
- >               --30E-360isda        use '30E/360isda' day counting convention
- >               --constant=RATE      constant interest rate
- >               --annual=RATE        annual interest rate
- >               --bgb288             compute interest according to German BGB288
+ >   -h          --help                      print this message and exit
+ >   -V          --version                   show version number and exit
+ >   -v          --verbose                   echo input ledger to stdout (default)
+ >   -q          --quiet                     don't echo input ledger to stdout
+ >               --today                     compute interest up until today
+ >   -f FILE     --file=FILE                 input ledger file (pass '-' for stdin)
+ >   -s ACCOUNT  --source=ACCOUNT            interest source account
+ >   -t ACCOUNT  --target=ACCOUNT            interest target account
+ >   -I          --ignore-assertions         ignore any failing balance assertions
+ >               --act                       use 'act' day counting convention
+ >               --30-360                    use '30/360' day counting convention
+ >               --30E-360                   use '30E/360' day counting convention
+ >               --30E-360isda               use '30E/360isda' day counting convention
+ >               --constant=RATE             constant interest rate
+ >               --annual-schedule=SCHEDULE  schedule of annual interest rates.
+ >                                           syntax: '[(Date1,Rate1),(Date2,Rate2),...]'
+ >               --annual=RATE               annual interest rate
+ >               --bgb288                    compute interest according to German BGB288
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
I've found out that once your annual interest rate changes,  you need quite a lot of finesse to keep using hledger-interest: you need to run it once with prior rate, then filter out all generated transactions past rate change date, then compute final balance at rate change date, then inject this balance into your journal that you supply to hledger-interest for the second run with a new rate ...

However, hledger-interest code could already accommodate all of this, you just need a way to supply rate schedule from the command line. This PR adds this ability.

Hope you like it. I tried to make minimal changes and follow your coding style, happy to accommodate any changes you need
