### PR TITLE
Fixes build vs hledger-lib 1.18

### DIFF
--- a/Hledger/Interest.hs
+++ b/Hledger/Interest.hs
@@ -64,7 +64,7 @@ computeInterest day = do
       to = min day endOfPeriod
       newFrom = succ to
   modify (\st -> st { balancedUntil = newFrom })
-  when (to >= from && not (isZeroMixedAmount bal)) $ do
+  when (to >= from && not (mixedAmountLooksZero bal)) $ do
     diff <- asks dayCountConvention
     t <- mkTrans to ((from `diff` to) + 1) ratePerAnno
     tell [t]

--- a/hledger-interest.cabal
+++ b/hledger-interest.cabal
@@ -1,5 +1,5 @@
 Name:                   hledger-interest
-Version:                1.5.4.1
+Version:                1.5.5
 Synopsis:               computes interest for a given account
 License:                BSD3
 License-file:           LICENSE
@@ -118,7 +118,7 @@ Source-Repository head
 
 Executable hledger-interest
   Main-is:              Main.hs
-  Build-depends:        base >= 3 && < 5, hledger-lib >= 1.9.1 && < 1.18, time, mtl, Cabal, Decimal, text
+  Build-depends:        base >= 3 && < 5, hledger-lib >= 1.18, time, mtl, Cabal, Decimal, text
   other-modules:        Hledger.Interest
                         Hledger.Interest.DayCountConvention
                         Hledger.Interest.Rate

--- a/hledger-interest.cabal
+++ b/hledger-interest.cabal
@@ -1,5 +1,5 @@
 Name:                   hledger-interest
-Version:                1.5.4
+Version:                1.5.4.1
 Synopsis:               computes interest for a given account
 License:                BSD3
 License-file:           LICENSE
@@ -118,7 +118,7 @@ Source-Repository head
 
 Executable hledger-interest
   Main-is:              Main.hs
-  Build-depends:        base >= 3 && < 5, hledger-lib >= 1.9.1, time, mtl, Cabal, Decimal, text
+  Build-depends:        base >= 3 && < 5, hledger-lib >= 1.9.1 && < 1.18, time, mtl, Cabal, Decimal, text
   other-modules:        Hledger.Interest
                         Hledger.Interest.DayCountConvention
                         Hledger.Interest.Rate

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-15.4
+
+packages:
+- .
+
+extra-deps:
+ - hledger-lib-1.18


### PR DESCRIPTION
Hi!
Hledger-interest 1.5.4 is not buildable with hledger-lib 1.18. To fix it, in this PR i am submitting 

1. A changeset that minds 1.5.4.1 with dependency on hledger-lib clamped at 1.18
2. A changeset minting 1.5.5 that depends on hledger-lib >= 1.18 and fixes the code for compilation vs 1.18

As 1.18 is not yet in any stackage snapshots, I included stack.yaml in the second changeset to ensure that code builds vs 1.18