### PR TITLE
Allow building with hledger-lib version 1.21.x

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -95,12 +95,12 @@ main = bracket (return ()) (\() -> hFlush stdout >> hFlush stderr) $ \() -> do
   jnl' <- readJournalFiles ledgerInputOptions (reverse (optInput opts)) >>= either fail return
   interestAcc <- case args of
                    []    -> commandLineError "required argument ACCOUNT is missing\n"
-                   [acc] -> return acc
+                   [acc] -> return $ T.pack acc
                    _     -> commandLineError "only one interest ACCOUNT may be specified\n"
   let jnl = filterJournalTransactions (Acct (toRegex' interestAcc)) jnl'
       ts  = sortOn tdate (jtxns jnl)
       cfg = Config
-            { interestAccount = T.pack interestAcc
+            { interestAccount = interestAcc
             , sourceAccount = T.pack (optSourceAcc opts)
             , targetAccount = T.pack (optTargetAcc opts)
             , dayCountConvention = fromJust (optDCC opts)
@@ -114,4 +114,4 @@ main = bracket (return ()) (\() -> hFlush stdout >> hFlush stderr) $ \() -> do
       result
         | optVerbose opts = ts' ++ ts
         | otherwise       = ts'
-  mapM_ (putStr . showTransactionUnelided) (sortOn tdate result)
+  mapM_ (putStr . T.unpack . showTransaction) (sortOn tdate result)

--- a/hledger-interest.cabal
+++ b/hledger-interest.cabal
@@ -1,5 +1,5 @@
 Name:                   hledger-interest
-Version:                1.6.0
+Version:                1.6.1
 Synopsis:               computes interest for a given account
 License:                BSD3
 License-file:           LICENSE
@@ -119,7 +119,7 @@ Source-Repository head
 Executable hledger-interest
   default-language:     Haskell2010
   Main-is:              Main.hs
-  Build-depends:        base >= 3 && < 5, hledger-lib >= 1.19 && < 1.21, time, mtl, Cabal, Decimal, text
+  Build-depends:        base >= 3 && < 5, hledger-lib >= 1.19 && < 1.22, time, mtl, Cabal, Decimal, text
   other-modules:        Hledger.Interest
                         Hledger.Interest.DayCountConvention
                         Hledger.Interest.Rate


### PR DESCRIPTION
Hi!

Current version of hledger-interest is not buildable with hledger-lib 1.21.x that was just released. This PR fixes the build.