### PR TITLE
Add the --until=YYYY-MM-DD option

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -82,7 +82,7 @@ commandLineError err = do hPutStrLn stderr (err ++ usageMessage)
 
 parseOpts :: [String] -> IO (Options, [String])
 parseOpts argv =
-   case getOpt Permute options argv of
+   case System.Console.GetOpt.getOpt Permute options argv of
       (o,n,[]  ) -> return (foldl (flip id) defaultOptions o, n)
       (_,_,errs) -> commandLineError (concat errs)
 


### PR DESCRIPTION
The option `--until=%Y-%-m-%-d` is similar to the option `--today` except that instead of computing interest until today it computes interest until the specified day.

Fixes #18.